### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/package/rpm/postinstall.sh
+++ b/src/main/package/rpm/postinstall.sh
@@ -7,7 +7,7 @@ from pprint import pprint
 
 def updateRepoWithScdf(repoinfoxml):
   scdf_repo='SCDF-@version@'
-  scdf_repo_str = '<repo><baseurl>http://repo.spring.io/@springYumRepoId@/scdf/@version@</baseurl><repoid>' + scdf_repo + '</repoid><reponame>' + scdf_repo + '</reponame></repo>'
+  scdf_repo_str = '<repo><baseurl>https://repo.spring.io/@springYumRepoId@/scdf/@version@</baseurl><repoid>' + scdf_repo + '</repoid><reponame>' + scdf_repo + '</reponame></repo>'
   is_scdfrepo_set = None
 
   tree = ET.parse(repoinfoxml)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repo.spring.io/@springYumRepoId@/scdf/@version@ (404) with 1 occurrences migrated to:  
  https://repo.spring.io/@springYumRepoId@/scdf/@version@ ([https](https://repo.spring.io/@springYumRepoId@/scdf/@version@) result 404).